### PR TITLE
Chunk exe

### DIFF
--- a/omnibenchmark/core/omni_object.py
+++ b/omnibenchmark/core/omni_object.py
@@ -122,7 +122,7 @@ class OmniObject(OmniRenkuInst):
         )
         return renku_dataset
 
-    def run_renku(self, all: bool = True, provider: str = "toil", config: Optional[str] = None):
+    def run_renku(self, all: bool = True, provider: str = "toil", config: Optional[str] = None, n:int = 10):
         self.command = check_omni_command(self.command, self.script, self.outputs)
         if self.outputs is not None:
             out_files = get_all_output_file_names(self.outputs)
@@ -136,7 +136,7 @@ class OmniObject(OmniRenkuInst):
         )
         if self.outputs is not None and all:
             manage_renku_activities(
-                outputs=self.outputs, omni_plan=self.omni_plan, provider=provider, config=config
+                outputs=self.outputs, omni_plan=self.omni_plan, provider=provider, config=config, n=n
             )
 
     def update_result_dataset(self, clean: bool = True):

--- a/omnibenchmark/management/run_commands.py
+++ b/omnibenchmark/management/run_commands.py
@@ -284,7 +284,7 @@ def get_all_output_file_names(output: OmniOutput) -> List[str]:
 
 
 def manage_renku_activities(
-    outputs: OmniOutput, omni_plan: OmniPlan, provider: str = "toil", config: Optional[str] = None, n: Optional[int] = 2
+    outputs: OmniOutput, omni_plan: OmniPlan, provider: str = "toil", config: Optional[str] = None, n: Optional[int] = 1
 ):
     """Manage renku activities by updating existing ones and generating new activities for output files without.
 

--- a/omnibenchmark/management/run_commands.py
+++ b/omnibenchmark/management/run_commands.py
@@ -284,7 +284,7 @@ def get_all_output_file_names(output: OmniOutput) -> List[str]:
 
 
 def manage_renku_activities(
-    outputs: OmniOutput, omni_plan: OmniPlan, provider: str = "toil", config: Optional[str] = None, n: int = 10
+    outputs: OmniOutput, omni_plan: OmniPlan, provider: str = "toil", config: Optional[str] = None, n: Optional[int] = 2
 ):
     """Manage renku activities by updating existing ones and generating new activities for output files without.
 
@@ -293,7 +293,7 @@ def manage_renku_activities(
         omni_plan (OmniPlan): A plan/workflow description with mappings to the output
         provider (str): Provider name to run workflow with
         config (str): Path to provider config file
-        n (int): Number of activities to be send in parallel to the provider. Execution will still depend on the provider itself.
+        n (Optional(int)): Number of activities to be send in parallel to the provider. Execution will still depend on the provider itself.
     """
     project_context.clear()
     out_files = get_all_output_file_names(outputs)
@@ -309,7 +309,8 @@ def manage_renku_activities(
 
     # create new activities:
     if len(no_activities) > 0:
-        no_act_chunks = [no_activities[i:i + n] for i in range(0, len(no_activities), n)]
+        n = len(no_activities) if n is None else n
+        no_act_chunks = [no_activities[i:i + n] for i in range(0, len(no_activities), n)] 
         for no_act in no_act_chunks:
             graph = create_execution_graph(no_act, omni_plan)
             omni_wflow.mod_renku_execute_workflow_graph(dag=graph.workflow_graph, provider=provider, config=config)
@@ -322,6 +323,7 @@ def manage_renku_activities(
     
     # update activities in parallel       
     if len(up_list) > 0:
+        n = len(up_list) if n is None else n
         up_list_chunks = [up_list[i:i + n] for i in range(0, len(up_list), n)]
         for up in up_list_chunks:
             omni_wflow.renku_update_activity(paths=up, provider=provider, config=config)

--- a/omnibenchmark/renku_commands/workflows.py
+++ b/omnibenchmark/renku_commands/workflows.py
@@ -137,6 +137,7 @@ def renku_update_activity(
     try:
         result = (
             update_command(skip_metadata_update=skip_metadata_update)
+            .with_commit()
             .build()
             .execute(
                 update_all=update_all,


### PR DESCRIPTION
Enable chunks of size n to be executed in parallel using toil. Defaults to one activity and needs to be actively increased to allow parallel execution. All successful activities/activity chunks will be automatically commited, but not pushed. 